### PR TITLE
Remove no-use-before-define from linter errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "airbnb-base"
+    "extends": "airbnb-base",
+    "rules": {
+      "no-use-before-define": [0]
+    }
 }


### PR DESCRIPTION
Closes #39 